### PR TITLE
[SHIP] Add headers for Sample1120 to allow MeF viewer to parse it

### DIFF
--- a/Sample1120.xml
+++ b/Sample1120.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Return returnVersion="2021v4.3" xmlns="http://www.irs.gov/efile">
+<Return xmlns="http://www.irs.gov/efile" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.irs.gov/efile" returnVersion="2021v4.3">
   <ReturnHeader subsidiaryReturnCount="0" binaryAttachmentCnt="0">
     <ReturnTs>1900-01-01T01:01:01-05:00</ReturnTs>
     <TaxPeriodEndDt>1900-01-01</TaxPeriodEndDt>


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

[Ticket link here](https://github.com/newjersey/affordability-pm/issues/1)
> Prototype works with externally hosted file, 1120 form fails to load when user uploads a file. Examining form_template.xml to see if additional modifications there are needed.

<!-- Summary of the changes, related issue, relevant motivation, and context -->

## Approach

> Root cause was not an issue with the MeF Viewer but with the input file itself. The header of the auto-generated 1120 did not contain xmlns:xsi and xsi:schemaLocation attributes, which caused the XPATH transforms to fail because it was not able to transfer elements from the inputDOM to the templateDOM. [Relevant code for XPATH transform](https://github.com/newjersey/taxation-mef-viewer/blob/main/js/transform.js#L296-L310)
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

## Steps to test
Tested this by hosting the viewer locally and verifying that I could upload files to localSessionStorage and view the resulting 1120.
<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

## Notes
> This brings up a good question -- which is to validate whether the files that DORES provides users have this header on the XML or not. I have been auto-generating the Sample1120 using the IRS' Schema, but the Schema does not specify these headers. We would expect it to contain all these headers but we should validate this.
<!-- Additional information, key learnings, and future development considerations. -->
