### PR TITLE
[SHOW] Enable GitHub Pages hosting

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -9,7 +9,7 @@ name: Deploy Jekyll site to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["gh-pages"]
+    branches: ["main"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@ repository: newjersey/taxation-mef-viewer
 url: https://newjersey.github.io
 
 github:
-  url: https://github.com/newjersey/taxation-mef-viewer/tree/master
+  url: https://github.com/newjersey/taxation-mef-viewer/tree/main
   repository_url: https://github.com/newjersey/taxation-mef-viewer
 
 bucket_url: https://jachan-test-cors-public.s3.amazonaws.com

--- a/_config.yml
+++ b/_config.yml
@@ -9,12 +9,4 @@ exclude: [
   'vendor'
 ]
 
-repository: newjersey/taxation-mef-viewer
-url: https://newjersey.github.io
-
-github:
-  url: https://github.com/newjersey/taxation-mef-viewer/tree/main
-  repository_url: https://github.com/newjersey/taxation-mef-viewer
-
 bucket_url: https://jachan-test-cors-public.s3.amazonaws.com
-

--- a/_config.yml
+++ b/_config.yml
@@ -9,4 +9,5 @@ exclude: [
   'vendor'
 ]
 
+repository: newjersey/taxation-mef-viewer
 bucket_url: https://jachan-test-cors-public.s3.amazonaws.com

--- a/_config.yml
+++ b/_config.yml
@@ -10,4 +10,5 @@ exclude: [
 ]
 
 repository: newjersey/taxation-mef-viewer
+url: newjersey.github.io/taxation-mef-viewer
 bucket_url: https://jachan-test-cors-public.s3.amazonaws.com

--- a/_config.yml
+++ b/_config.yml
@@ -10,8 +10,9 @@ exclude: [
 ]
 
 github:
-  url: https://github.com/betson/irs-efile-viewer/tree/master
+  url: https://github.com/newjersey/taxation-mef-viewer/tree/master
   repository_url: https://github.com/newjersey/taxation-mef-viewer
+  repository_nwo: newjersey/taxation-mef-viewer
 
 bucket_url: https://jachan-test-cors-public.s3.amazonaws.com
 

--- a/_config.yml
+++ b/_config.yml
@@ -9,10 +9,12 @@ exclude: [
   'vendor'
 ]
 
+repository: newjersey/taxation-mef-viewer
+url: https://newjersey.github.io
+
 github:
   url: https://github.com/newjersey/taxation-mef-viewer/tree/master
   repository_url: https://github.com/newjersey/taxation-mef-viewer
-  repository_nwo: newjersey/taxation-mef-viewer
 
 bucket_url: https://jachan-test-cors-public.s3.amazonaws.com
 

--- a/_config.yml
+++ b/_config.yml
@@ -10,5 +10,7 @@ exclude: [
 ]
 
 repository: newjersey/taxation-mef-viewer
-url: newjersey.github.io/taxation-mef-viewer
 bucket_url: https://jachan-test-cors-public.s3.amazonaws.com
+github:
+  url: https://newjersey.github.io
+  repository_url: https://github.com/newjersey/taxation-mef-viewer

--- a/_config.yml
+++ b/_config.yml
@@ -12,5 +12,5 @@ exclude: [
 repository: newjersey/taxation-mef-viewer
 bucket_url: https://jachan-test-cors-public.s3.amazonaws.com
 github:
-  url: https://newjersey.github.io
+  url: https://newjersey.github.io/taxation-mef-viewer
   repository_url: https://github.com/newjersey/taxation-mef-viewer


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

[Ticket link here](https://github.com/newjersey/affordability-pm/issues/1)

<!-- Summary of the changes, related issue, relevant motivation, and context -->
We need to host the site so DOT employees can view it. These config changes allow the Github Pages workflow to build and deploy the Jekyll site.
## Approach
Modifications from the original repository config files to point to our NJ GitHub Pages domain.
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

## Steps to test
1. Originally configured the workflow to run on changes to the `gh-pages` branch, [this latest deploy](https://github.com/newjersey/taxation-mef-viewer/actions/runs/8650588487) was successful.
2. Validated that network requests succeed to load site assets at https://newjersey.github.io/taxation-mef-viewer 
<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

## Notes

<!-- Additional information, key learnings, and future development considerations. -->
Workflow was originally introduced in this [SHIP] PR: https://github.com/newjersey/taxation-mef-viewer/pull/10/files
