### PR TITLE
Added support for multiple forms with the same formName

### DIFF
--- a/js/transform.js
+++ b/js/transform.js
@@ -395,7 +395,7 @@ function setNodeValue(dom, nodeName, value) {
 // given the provided e-file form
 function getStylesheetPath(templateDom, formId) {
     var year = templateDom.getElementsByTagName('ReturnVersion')[0].textContent.match(/\d+/)[0];
-    return '{{ site.amplify_url }}/mef/Stylesheets/'+year+'/'+formId+'.xsl';
+    return `{{ site.amplify_url }}/mef/Stylesheets/${year}/${formId}.xsl`;
 }
 
 //======================================

--- a/js/transform.js
+++ b/js/transform.js
@@ -276,14 +276,14 @@ function generateAndDisplayForm(formId, dest) {
             destWindow.document.write(formHtml);
             destWindow.document.write('<link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet"><link href="{{site.amplify_url}}/css/form-display.css" rel="stylesheet"><footer class="noprint"><button class="print-button" onclick="print()"><span class="fa fa-print" aria-hidden="true"></span>Print Form</button></footer>');
             destWindow.document.close();
-            destWindow.history.replaceState(null, null, location.href.replace(location.hash, '')+'#'+formName);
+            destWindow.history.replaceState(null, null, `${location.href.replace(location.hash, '')}#${formName}`);
         }
     }).catch(function(error) {
         console.log(error);
         if(destWindow) {
             destWindow.close();
         }
-        displayFormError('There was a problem generating ' + getDisplayName(formName) + '.', formName);
+        displayFormError(`There was a problem generating ${getDisplayName(formName)}.`, formName);
     });
 }
 

--- a/js/transform.js
+++ b/js/transform.js
@@ -87,7 +87,7 @@ function addXMLToPage(inputDom) {
     forms.forEach(function(formName) {
         $('#forms-list').append(
             $('<li>').append(
-                $('<a>').attr({href: '#'+formName, id: formName}).append(
+                $('<a>').attr({href: `#${formName}`, id: formName}).append(
                     $('<span>').append(getDisplayName(formName, true)),
                     $('<span>').append(getDisplayName(formName))
                 )
@@ -238,7 +238,7 @@ function generateAndDisplayForm(formId, dest) {
         var formName = match[1]
         var  formIndex= match[2]
     } else {
-        throw Error('Could not parse formId with regex. Expected formId to be of form .*_([0-9]+). Instead formId was ${formId}');
+        throw Error(`Could not parse formId with regex. Expected formId to be of form .*_([0-9]+). Instead formId was ${formId}`);
     }
 
     if(!sessionStorage[inputStorageId()] || !sessionStorage['template']) {

--- a/js/transform.js
+++ b/js/transform.js
@@ -24,7 +24,7 @@ $(function() {
 
 // Attempt to load the user-provided XML e-file
 function gatherInputXML(inputFile) {
-    var templateFile = '{{ site.amplify_url}}/form_template.xml';
+    var templateFile = '{{ site.amplify_url }}/form_template.xml';
     var templateStr = sessionStorage.getItem('template');
     var inputStr = sessionStorage.getItem(inputStorageId());
 
@@ -119,8 +119,18 @@ function getNameAndTaxYear(inputDom) {
 function getListOfForms(inputDom) {
     var returnData = inputDom.getElementsByTagName('ReturnData')[0];
     var children = returnData ? Array.prototype.slice.call(returnData.children) : [];
+    var childCounts = {};
     return children.map(function(child) {
-        return child.nodeName;
+        // If the element has not been counted yet, initialize its count
+        if (!Object.hasOwn(childCounts, child.nodeName)) {
+            childCounts[child.nodeName] = 0;
+        } else {
+            // If the element has already been counted, increment its count
+            childCounts[child.nodeName]++;
+        }
+
+        // Append the count to the element to make it unique
+        return `${child.nodeName}_${childCounts[child.nodeName]}`;
     });
 }
 
@@ -222,6 +232,15 @@ function displayForm(e) {
 }
 
 function generateAndDisplayForm(formId, dest) {
+    const INTEGER_AFTER_UNDERSCORE_REGEX = /(.*)_([0-9]+)/;
+    const match = formId.match(INTEGER_AFTER_UNDERSCORE_REGEX);
+    if (match) {
+        var formName = match[1]
+        var formIterator = match[2]
+    } else {
+        throw Error('Could not parse formId with regex. Expected formId to be of form .*_([0-9]+). Instead formId was ' + formId);
+    }
+
     if(!sessionStorage[inputStorageId()] || !sessionStorage['template']) {
         displayFormError('There was a problem generating ' + getDisplayName(formId) + '.', formId);
         throw Error('Could not load input XML file from sessionStorage');
@@ -234,9 +253,9 @@ function generateAndDisplayForm(formId, dest) {
     var templateDom = parser.parseFromString(sessionStorage.getItem('template'), 'text/xml');
 
     // Configure template file
-    moveHeaderAndMainForm(inputDom, templateDom, formId);
-    setFormProperties(inputDom, templateDom, formId);
-    var stylesheetPath = getStylesheetPath(templateDom, formId);
+    moveHeaderAndMainForm(inputDom, templateDom, formName, formIterator);
+    setFormProperties(inputDom, templateDom, formName);
+    var stylesheetPath = getStylesheetPath(templateDom, formName);
 
     // Display rendered form to the user
     // In order to display the form in a separate window, the action
@@ -257,14 +276,14 @@ function generateAndDisplayForm(formId, dest) {
             destWindow.document.write(formHtml);
             destWindow.document.write('<link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet"><link href="{{site.amplify_url}}/css/form-display.css" rel="stylesheet"><footer class="noprint"><button class="print-button" onclick="print()"><span class="fa fa-print" aria-hidden="true"></span>Print Form</button></footer>');
             destWindow.document.close();
-            destWindow.history.replaceState(null, null, location.href.replace(location.hash, '')+'#'+formId);
+            destWindow.history.replaceState(null, null, location.href.replace(location.hash, '')+'#'+formName);
         }
     }).catch(function(error) {
         console.log(error);
         if(destWindow) {
             destWindow.close();
         }
-        displayFormError('There was a problem generating ' + getDisplayName(formId) + '.', formId);
+        displayFormError('There was a problem generating ' + getDisplayName(formName) + '.', formName);
     });
 }
 
@@ -280,10 +299,11 @@ function removeNamespaces(XMLString) {
 }
 
 // Move the main form data into the template
-function moveHeaderAndMainForm(inputDom, templateDom, formId) {
-    var formData = inputDom.getElementsByTagName(formId)[0];
+// formIterator allows the function to access elements when there are multiple elements with the same formName
+function moveHeaderAndMainForm(inputDom, templateDom, formName, formIterator = 0) {
+    // only the form data changes between elements with matching formNames, formHeader, tHeader, and tData all stay the same
+    var formData = inputDom.getElementsByTagName(formName)[formIterator];
     var formHeader = inputDom.getElementsByTagName('ReturnHeader')[0];
-
     var tHeader = templateDom.getElementsByTagName('ReturnHeader')[0];
     var tData = templateDom.getElementsByTagName('SubmissionDocument')[0];
     tHeader.parentNode.replaceChild(formHeader.cloneNode(true), tHeader);
@@ -375,7 +395,7 @@ function setNodeValue(dom, nodeName, value) {
 // given the provided e-file form
 function getStylesheetPath(templateDom, formId) {
     var year = templateDom.getElementsByTagName('ReturnVersion')[0].textContent.match(/\d+/)[0];
-    return '{{ site.amplify_url}}/mef/Stylesheets/'+year+'/'+formId+'.xsl';
+    return '{{ site.amplify_url }}/mef/Stylesheets/'+year+'/'+formId+'.xsl';
 }
 
 //======================================

--- a/js/transform.js
+++ b/js/transform.js
@@ -119,18 +119,18 @@ function getNameAndTaxYear(inputDom) {
 function getListOfForms(inputDom) {
     var returnData = inputDom.getElementsByTagName('ReturnData')[0];
     var children = returnData ? Array.prototype.slice.call(returnData.children) : [];
-    var childCounts = {};
-    return children.map(function(child) {
-        // If the element has not been counted yet, initialize its count
-        if (!Object.hasOwn(childCounts, child.nodeName)) {
-            childCounts[child.nodeName] = 0;
+    const childCounts = {};
+    return children.map(child => { 
+        const { nodeName } = child
+        if (!Object.hasOwn(childCounts, nodeName)) {
+            // If the element has not been counted yet, initialize its count
+            childCounts[nodeName] = 0;
         } else {
             // If the element has already been counted, increment its count
-            childCounts[child.nodeName]++;
+            childCounts[nodeName]++;
         }
-
         // Append the count to the element to make it unique
-        return `${child.nodeName}_${childCounts[child.nodeName]}`;
+        return `${nodeName}_${childCounts[nodeName]}`;
     });
 }
 
@@ -231,14 +231,14 @@ function displayForm(e) {
     generateAndDisplayForm($(this).attr('id'));
 }
 
+const INTEGER_AFTER_UNDERSCORE_REGEX = /(.*)_([0-9]+)/;
 function generateAndDisplayForm(formId, dest) {
-    const INTEGER_AFTER_UNDERSCORE_REGEX = /(.*)_([0-9]+)/;
     const match = formId.match(INTEGER_AFTER_UNDERSCORE_REGEX);
     if (match) {
         var formName = match[1]
-        var formIterator = match[2]
+        var  formIndex= match[2]
     } else {
-        throw Error('Could not parse formId with regex. Expected formId to be of form .*_([0-9]+). Instead formId was ' + formId);
+        throw Error('Could not parse formId with regex. Expected formId to be of form .*_([0-9]+). Instead formId was ${formId}');
     }
 
     if(!sessionStorage[inputStorageId()] || !sessionStorage['template']) {
@@ -253,7 +253,7 @@ function generateAndDisplayForm(formId, dest) {
     var templateDom = parser.parseFromString(sessionStorage.getItem('template'), 'text/xml');
 
     // Configure template file
-    moveHeaderAndMainForm(inputDom, templateDom, formName, formIterator);
+    moveHeaderAndMainForm(inputDom, templateDom, formName, formIndex);
     setFormProperties(inputDom, templateDom, formName);
     var stylesheetPath = getStylesheetPath(templateDom, formName);
 
@@ -299,10 +299,10 @@ function removeNamespaces(XMLString) {
 }
 
 // Move the main form data into the template
-// formIterator allows the function to access elements when there are multiple elements with the same formName
-function moveHeaderAndMainForm(inputDom, templateDom, formName, formIterator = 0) {
+// formIndex specifies which multiple elements with the same formName should be accessed
+function moveHeaderAndMainForm(inputDom, templateDom, formName, formIndex = 0) {
     // only the form data changes between elements with matching formNames, formHeader, tHeader, and tData all stay the same
-    var formData = inputDom.getElementsByTagName(formName)[formIterator];
+    var formData = inputDom.getElementsByTagName(formName)[formIndex];
     var formHeader = inputDom.getElementsByTagName('ReturnHeader')[0];
     var tHeader = templateDom.getElementsByTagName('ReturnHeader')[0];
     var tData = templateDom.getElementsByTagName('SubmissionDocument')[0];


### PR DESCRIPTION
<!-- Please complete the following sections as necessary. -->

## Description

[Ticket link here](https://github.com/newjersey/taxation-mef-viewer/issues/18)

> User feedback: "IRS926 – The dashboard correctly shows that there are 5 iterations of this form from the federal XML. However, each instance is a repeat of the first and does not show data from the correct iteration. So the second instance of IRS926 still shows data from the first iteration in the XML, the third instance shows data from the first, and so on. Can verify by looking at the unique values shown in IRS926\CashPropertyGrp\FairMarketValueAmt."

> Investigation of ticket https://github.com/newjersey/taxation-mef-viewer/issues/17 revealed that there is a bug in the MeF viewer. When a tax form with multiple instances of the same form (e.g. multiple 926) is viewed, all forms display the data in the first instance of the form.

<!-- Summary of the changes, related issue, relevant motivation, and context -->

## Approach
This solution requires two parts. First, the page must be updated to differentiate between each instance of a form. Currently, no distinction is made, as all forms are simply referenced by the `formName` (e.g. 926). This PR changes `formId` to include a disambiguator (e.g. IRS926_0) when multiple forms with the same name exist.

Second, the function that displays the form when selected must be updated to pull the correct information from the XML DOM. This is done by pulling the index of the form element from the `formId` disambiguator.
<!-- Any changed dependencies, e.g. requires an install/update/migration, etc. -->

## Steps to test
Tested by running locally and validating that I am able to see distinct forms for XML files with multiple 926 forms. Additionally validated that opening each form shows distinct data which matches the XML data.

Current site - note that the two 926 forms are incorrectly displayed as identical to the user:
<img width="808" alt="image" src="https://github.com/newjersey/taxation-mef-viewer/assets/4315803/7d592945-ce90-4b31-8892-e50a284ca23f">

<img width="720" alt="image" src="https://github.com/newjersey/taxation-mef-viewer/assets/4315803/685dae47-47c3-465b-ba21-4d639462e1e4">

<img width="731" alt="image" src="https://github.com/newjersey/taxation-mef-viewer/assets/4315803/a59b2fab-1462-4a17-a80b-9fbaf5961e16">


Locally Hosted (with fix) - note that the two 926 forms are correct displayed as having unique data:
<img width="871" alt="image" src="https://github.com/newjersey/taxation-mef-viewer/assets/4315803/d263d0a9-3075-41f9-97c3-ce3b9df8ee58">

<img width="731" alt="image" src="https://github.com/newjersey/taxation-mef-viewer/assets/4315803/b55e2adc-e628-464e-9ba7-3a58c4e59f16">

<img width="736" alt="image" src="https://github.com/newjersey/taxation-mef-viewer/assets/4315803/108defad-3a68-4b34-9160-3a1fac28ef0b">


<!-- If this work affects a user's experience, provide steps to test these changes in-app. -->

## Notes

<!-- Additional information, key learnings, and future development considerations. -->
Note: I really want to add a testing framework to this package, especially as I start tinkering with the logic of the transform. Open question: Should that be done in a separate PR or do I bundle it into this one?